### PR TITLE
update the kafka dependencies and containers and the required code

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ in our experiments will follow.
 
 Using either the provided or your own csv files, you can run the experiments using the following script from the ***root*** 
 of the repository:  
-`./scripts/run_batch_experiments.sh location_of_the_csv_file directory_to_save_results`
+`./scripts/run_batch_exp.sh location_of_the_csv_file directory_to_save_results`
 
 <ins>Note</ins>: To run experiments with NexMark queries, you must first build the generator. 
 To build the generator, run `mvn clean package` from nexmark directory. Java 11 and maven are required. 

--- a/coordinator/requirements.txt
+++ b/coordinator/requirements.txt
@@ -7,6 +7,6 @@ aiozmq==1.0.0
 # monitoring service
 # psutil==5.9.1
 # kafka
-kafka-python==2.0.2
+confluent-kafka==2.8.0
 # snapshots
 minio==7.1.17

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,68 +1,92 @@
-version: "3"
 services:
-
-  zookeeper:
-    image: bitnami/zookeeper:3.8.0
-    container_name: zookeeper
+  zoo1:
+    image: confluentinc/cp-zookeeper:7.8.0
+    hostname: zoo1
+    container_name: zoo1
     ports:
-      - '2181:2181'
+      - "2181:2181"
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
+
+  zoo2:
+    image: confluentinc/cp-zookeeper:7.8.0
+    hostname: zoo2
+    container_name: zoo2
+    ports:
+      - "2182:2182"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2182
+      ZOOKEEPER_SERVER_ID: 2
+      ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
+
+  zoo3:
+    image: confluentinc/cp-zookeeper:7.8.0
+    hostname: zoo3
+    container_name: zoo3
+    ports:
+      - "2183:2183"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2183
+      ZOOKEEPER_SERVER_ID: 3
+      ZOOKEEPER_SERVERS: zoo1:2888:3888;zoo2:2888:3888;zoo3:2888:3888
+
 
   kafka1:
-    image: bitnami/kafka:3.2.0
+    image: confluentinc/cp-kafka:7.8.0
+    hostname: kafka1
     container_name: kafka1
     ports:
-      - '9093:9093'
+      - "9092:9092"
     environment:
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka1:9092,EXTERNAL://localhost:9093
-      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
-      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
+      KAFKA_BROKER_ID: 1
+      KAFKA_MESSAGE_MAX_BYTES: 134217728      # 128MB
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 134217728  # 128MB
     depends_on:
-      - zookeeper
+      - zoo1
+      - zoo2
+      - zoo3
 
   kafka2:
-    image: bitnami/kafka:3.2.0
+    image: confluentinc/cp-kafka:7.8.0
+    hostname: kafka2
     container_name: kafka2
     ports:
-      - '9094:9094'
+      - "9093:9093"
     environment:
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9094
-      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka2:9092,EXTERNAL://localhost:9094
-      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
-      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka2:19093,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
+      KAFKA_BROKER_ID: 2
+      KAFKA_MESSAGE_MAX_BYTES: 134217728      # 128MB
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 134217728  # 128MB
     depends_on:
-      - zookeeper
+      - zoo1
+      - zoo2
+      - zoo3
+
 
   kafka3:
-    image: bitnami/kafka:3.2.0
+    image: confluentinc/cp-kafka:7.8.0
+    hostname: kafka3
     container_name: kafka3
     ports:
-      - '9095:9095'
+      - "9094:9094"
     environment:
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9095
-      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka3:9092,EXTERNAL://localhost:9095
-      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
-      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka3:19094,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
+      KAFKA_BROKER_ID: 3
+      KAFKA_MESSAGE_MAX_BYTES: 134217728      # 128MB
+      KAFKA_REPLICA_FETCH_MAX_BYTES: 134217728  # 128MB
     depends_on:
-      - zookeeper
-
-  kafdrop:
-    image: obsidiandynamics/kafdrop:latest
-    container_name: kafdrop
-    ports:
-      - '9010:9000'
-    environment:
-      - KAFKA_BROKERCONNECT=kafka1:9092,kafka2:9092,kafka3:9092
-    depends_on:
-      - kafka1
+      - zoo1
+      - zoo2
+      - zoo3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "8886:8888"
     environment:
-      - KAFKA_URL=kafka1:9092
+      - KAFKA_URL=kafka1:19092
     env_file:
       - env-example/minio.env
 
@@ -20,7 +20,7 @@ services:
     image: dev/universalis:latest
     environment:
       - INGRESS_TYPE=KAFKA
-      - KAFKA_URL=kafka1:9092
+      - KAFKA_URL=kafka1:19092
       - DISCOVERY_HOST=coordinator
       - DISCOVERY_PORT=8888
       - UNC_LOG_PATH=/usr/local/universalis/unc-logs

--- a/universalis-package/setup.py
+++ b/universalis-package/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     install_requires=[
         'cloudpickle>=3.0.0,<4.0.0',
         'msgspec>=0.18.4,<1.0.0',
-        'aiokafka>=0.8.1,<1.0',
+        'aiokafka>=0.12.0,<1.0',
     ],
     python_requires='>=3.11',
 )

--- a/universalis-package/universalis/common/kafka_rate_limited_producer.py
+++ b/universalis-package/universalis/common/kafka_rate_limited_producer.py
@@ -1,9 +1,8 @@
 import asyncio
-import os
 
 from aiokafka import AIOKafkaProducer
 from aiokafka.structs import RecordMetadata
-from kafka.errors import KafkaConnectionError
+from aiokafka.errors import KafkaConnectionError
 from universalis.common.logging import logging
 
 

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -7,6 +7,6 @@ aiozmq==1.0.0
 # monitoring service
 # psutil==5.9.2
 # Kafka
-aiokafka==0.8.1
+aiokafka==0.12.0
 # snapshots
 minio==7.1.17


### PR DESCRIPTION
This addresses issues related to the deprecated `python-kafka` package by exchanging it with the confluent alternative and also bumping up aiokafka to not use it.